### PR TITLE
Fix for bobplates referencing aluminium twice and support for Clowns-Extended-Minerals.

### DIFF
--- a/functions.lua
+++ b/functions.lua
@@ -108,6 +108,20 @@ function yutil.get_item_icon(scrap_type)
     ["copper-tungsten"]  = yutil.get_icon_bycolor("red", 2),
     chromium      = yutil.get_icon_bycolor("grey", 1),
     tellurium     = yutil.get_icon_bycolor("purple", 1),
+    adamantite    = yutil.get_icon_bycolor("purple", 1),
+    antitate      = yutil.get_icon_bycolor("red", 1),
+    ["pro-galena"]= yutil.get_icon_bycolor("dgrey", 1),
+    orichalcite   = yutil.get_icon_bycolor("orange", 1),
+    phosphorite   = yutil.get_icon_bycolor("grey", 1),
+    sanguinate    = yutil.get_icon_bycolor("red", 1),
+    elionagate    = yutil.get_icon_bycolor("teal", 1),
+    ["meta-garnierite"] = yutil.get_icon_bycolor("yellow", 1),
+    ["nova-leucoxene"] = yutil.get_icon_bycolor("dgrey", 1),
+    stannic = yutil.get_icon_bycolor("green", 3),
+    plumbic = yutil.get_icon_bycolor("purple", 3),
+    manganic = yutil.get_icon_bycolor("orange", 3),
+    titanic = yutil.get_icon_bycolor("grey", 3),
+    phosphic = yutil.get_icon_bycolor("teal", 3),
   }
   return icons[scrap_type] or icons.missing
 end

--- a/mods.lua
+++ b/mods.lua
@@ -24,6 +24,12 @@ if (mods["bobplates"]) then
   "brass", "bronze", "nitinol", "invar", "cobalt", "quartz", "silicon", "gunmetal", "tungsten" })
   yutil.table.extend(_results, {"alloy", "glass"})
 end
+if (mods['Clowns-Extended-Minerals']) then
+    yutil.table.extend(_types, {"adamantite", "orichalcite", "phosphorite", "eliongate"})
+    if clowns and not clowns.special_vanilla then
+        yutil.table.extend(_types, {"antitate", "pro-galena", "saguinate", "meta-garnierite", "nova-leucoxene", "stannic", "plumbic", "manganic", "titanic", "phosphic"})
+    end
+end
 if (mods['bztitanium']) then
   yutil.table.extend(_types, {"titanium"})
 end

--- a/mods.lua
+++ b/mods.lua
@@ -21,7 +21,7 @@ if (mods['angelssmelting']) then
 end
 if (mods["bobplates"]) then
   yutil.table.extend(_types, {"cobalt-steel", "copper-tungsten", "lead", "titanium", "zinc", "nickel", "aluminium", "tungsten-carbide", "tin", "silver", "gold",
-  "brass", "bronze", "nitinol", "invar", "cobalt", "quartz", "silicon", "gunmetal", "aluminium" })
+  "brass", "bronze", "nitinol", "invar", "cobalt", "quartz", "silicon", "gunmetal", "tungsten" })
   yutil.table.extend(_results, {"alloy", "glass"})
 end
 if (mods['bztitanium']) then


### PR DESCRIPTION
bobplates was referencing aluminium twice, and was not referencing tungsten, so I replaced the second instance with tungsten.

I also added support for Clowns-Extended-Minerals, as Ive never actually gotten far enough to get to the mixed types the colors are a best guess from the information I was able to find while researching, but its fine if you update them if you find something that works better.